### PR TITLE
lnst: Match tc rule by eth_type instead of protocol

### DIFF
--- a/recipes/ovs_offload/01-basic.py
+++ b/recipes/ovs_offload/01-basic.py
@@ -70,7 +70,7 @@ def verify_tc_rules(proto):
 
 if ipv in ('ipv4', 'both'):
     ping()
-    verify_tc_rules('ip')
+    verify_tc_rules('ipv4')
     for size in (200, 400, 1000):
         ping({'size': size})
 

--- a/recipes/ovs_offload/03-vlan_in_host.py
+++ b/recipes/ovs_offload/03-vlan_in_host.py
@@ -65,7 +65,7 @@ ctl.wait(2)
 for _ in range(2):
     if ipv in ('ipv4', 'both'):
         g1.run(ping_mod)
-        verify_tc_rules('ip')
+        verify_tc_rules('ipv4')
 
     if ipv in ('ipv6', 'both'):
         g1.run(ping_mod6)

--- a/recipes/ovs_offload/1_virt_ovs_vxlan.py
+++ b/recipes/ovs_offload/1_virt_ovs_vxlan.py
@@ -41,7 +41,7 @@ def do_pings():
              (host2, h2_nic, 0, {"scope": 0}),
              options=ping_opts, expect="pass")
         if not skip_tc_verify:
-            verify_tc_rules('ip')
+            verify_tc_rules('ipv4')
 
     if ipv in ['ipv6', 'both']:
         ping6((guest1, g1_nic, 1, {"scope": 0}),

--- a/recipes/ovs_offload/1_virt_ovs_vxlan_turn_off_sriov.py
+++ b/recipes/ovs_offload/1_virt_ovs_vxlan_turn_off_sriov.py
@@ -47,7 +47,7 @@ def do_test():
         turn_off_sriov()
         ctl.wait(2)
         ping_proc.intr()
-        verify_tc_rules('ip')
+        verify_tc_rules('ipv4')
 
     if ipv in ['ipv6', 'both']:
         ping_proc = ping6((guest1, g1_nic, 1, {"scope": 0}),

--- a/recipes/ovs_offload/Testlib.py
+++ b/recipes/ovs_offload/Testlib.py
@@ -45,8 +45,8 @@ class Testlib:
             return None
 
         # find rule
-        pat_filter = r"^protocol %s pref .* dst_mac %s\n\s*src_mac %s\n.*\n\s*action order \s*\d+\s*:\s* %s" % (
-                proto, str(dst_mac).lower(), str(src_mac).lower(), action)
+        pat_filter = r"^protocol .* pref .* dst_mac %s\n\s*src_mac %s\n\s*eth_type %s\n.*\n\s*action order \s*\d+\s*:\s* %s" % (
+                str(dst_mac).lower(), str(src_mac).lower(), proto, action)
         pat_action = r".*\n\s*action order .* %s.*\n\s*Sent (?P<bytes>\d+) bytes (?P<pkts>\d+) pkt \(dropped (?P<drop>\d+), overlimits \d+ requeues \d+\)" % action
 
         logging.debug("device %s pattern '%s' action '%s'", dev, pat_filter, pat_action)


### PR DESCRIPTION
In backport there is an issue to use specific protocol and it's protocol is always "all" but eth_type is ok.

Update Testlib.py to match eth_type instead of protocol in regular expressions.

Update 01-basic.py, 03-vlan_in_host.py, 1_virt_ovs_vxlan.py and 1_virt_ovs_vxlan_turn_off_sriov.py to send "ipv4" protocol instead of "ip".

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>