### PR TITLE
Update representors names in lnst pool reg019-001

### DIFF
--- a/ovs02_reg_vrt_019_001/reg_vrt_019_001.xml
+++ b/ovs02_reg_vrt_019_001/reg_vrt_019_001.xml
@@ -11,12 +11,12 @@
                     <param name="hwaddr" value="24:8a:07:9a:16:82" />
             </params>
        </eth>
-       <eth id="eth0" label="net019_001-vm1">
+       <eth id="ens1f0_0" label="net019_001-vm1">
             <params>
                     <param name="hwaddr" value="d2:f7:8a:3e:46:ef" />
             </params>
        </eth>
-       <eth id="eth1" label="net019_001-vm2">
+       <eth id="ens1f0_1" label="net019_001-vm2">
             <params>
                     <param name="hwaddr" value="9a:99:0b:29:f0:25" />
             </params>


### PR DESCRIPTION
This is for the mac update script to find correct nics after enabling centos7.2 to use the udev rule to update representor names so the names are ens1f0_0 and ens1f0_1.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>