### PR TITLE
mars/bash.cases: Add vf-vf-iperf and ovs-vxlan-in-ns-hw run cases

### DIFF
--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -204,6 +204,17 @@
         </cmd>
     </case>
     <case>
+        <tags> ovs </tags>
+        <tags> vxlan </tags>
+        <tags> vxlan-tc-hw </tags>
+        <name> test-ovs-vxlan-in-ns-hw.sh </name>
+        <cmd>
+            <params>
+                <test> test-ovs-vxlan-in-ns-hw.sh </test>
+            </params>
+        </cmd>
+    </case>
+    <case>
         <ignore>
             <bug> 1123491 </bug>
         </ignore>
@@ -403,6 +414,31 @@
         <cmd>
             <params>
                 <test> test-vf-vf-ping.sh </test>
+            </params>
+        </cmd>
+    </case>
+    <case>
+        <ignore>
+            <bug> 1251244 </bug>
+        </ignore>
+        <tags> vf </tags>
+        <name> test-vf-vf-iperf.sh </name>
+        <cmd>
+            <params>
+                <test> test-vf-vf-iperf.sh </test>
+            </params>
+        </cmd>
+    </case>
+    <case>
+        <ignore>
+            <bug> 1251244 </bug>
+        </ignore>
+        <tags> vf </tags>
+        <name> test-vf-vf-iperf.sh mutlipath enabled </name>
+        <cmd>
+            <params>
+                <test> test-vf-vf-iperf.sh </test>
+                <option> MULTIPATH=1 </option>
             </params>
         </cmd>
     </case>

--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -204,17 +204,6 @@
         </cmd>
     </case>
     <case>
-        <tags> ovs </tags>
-        <tags> vxlan </tags>
-        <tags> vxlan-tc-hw </tags>
-        <name> test-ovs-vxlan-in-ns-hw.sh </name>
-        <cmd>
-            <params>
-                <test> test-ovs-vxlan-in-ns-hw.sh </test>
-            </params>
-        </cmd>
-    </case>
-    <case>
         <ignore>
             <bug> 1123491 </bug>
         </ignore>


### PR DESCRIPTION
Add single run case for test-vf-vf-iperf.sh and ignore by bug 1251244.
Add two run cases for test-ovs-vxlan-in-ns-hw.sh with & without
MULTIPATH enabled.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>