### PR TITLE
mars/bash.cases: Add vf-vf-iperf run case

### DIFF
--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -407,6 +407,18 @@
         </cmd>
     </case>
     <case>
+        <ignore>
+            <bug> 1251244 </bug>
+        </ignore>
+        <tags> vf </tags>
+        <name> test-vf-vf-iperf.sh </name>
+        <cmd>
+            <params>
+                <test> test-vf-vf-iperf.sh </test>
+            </params>
+        </cmd>
+    </case>
+    <case>
 <!--
         <ignore>
             <bug> 1241076 </bug>

--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -204,6 +204,17 @@
         </cmd>
     </case>
     <case>
+        <tags> ovs </tags>
+        <tags> vxlan </tags>
+        <tags> vxlan-tc-hw </tags>
+        <name> test-ovs-vxlan-in-ns-hw.sh </name>
+        <cmd>
+            <params>
+                <test> test-ovs-vxlan-in-ns-hw.sh </test>
+            </params>
+        </cmd>
+    </case>
+    <case>
         <ignore>
             <bug> 1123491 </bug>
         </ignore>


### PR DESCRIPTION
Add a single run case for test-vf-vf-iperf.sh and ignore by
bug 1251244.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>