### PR TITLE
mars/bash.cases: Remove ignore by bug from tc-shuffle-4 test

### DIFF
--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -363,10 +363,12 @@
         </cmd>
     </case>
     <case>
-        <ignore>
+<!--        <ignore>
             <bug> 1241076 </bug>
         </ignore>
+-->
         <tags> tc </tags>
+        <tags> tc-shuffle-4 </tags>
         <name> test-tc-shuffle-4.sh </name>
         <cmd>
             <params>


### PR DESCRIPTION
Add tag to be able to ignore on some setups and run on other setups.
This feature is not available in mars yet using the ignore bug.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>