### PR TITLE
mars/bash.cases: Disable ignore by bug tc-shuffle-4 to run on backport

### DIFF
--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -386,9 +386,10 @@
         </cmd>
     </case>
     <case>
-        <ignore>
+<!--    <ignore>
             <bug> 1241076 </bug>
         </ignore>
+-->
         <tags> tc </tags>
         <tags> tc-shuffle-4 </tags>
         <name> test-tc-shuffle-4.sh </name>


### PR DESCRIPTION
Disable ignore by bug for test "test-tc-shuffle-4.sh" to make it runs on backport.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>