### PR TITLE
mars/bash.cases: Enable ignore by bug 1223798 for test-vf-veth-fwd.sh

### DIFF
--- a/mars/bash.cases
+++ b/mars/bash.cases
@@ -514,11 +514,9 @@
         </cmd>
     </case>
     <case>
-<!--
         <ignore>
             <bug> 1223798 </bug>
         </ignore>
--->
         <tags> vf </tags>
         <tags> vf-veth-fwd </tags>
         <name> test-vf-veth-fwd.sh </name>


### PR DESCRIPTION
Issue supposed to be fixed on backport so when it is closed, the test
will run on setups during the nightly runs.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>