### PR TITLE
lnst: 03-vlan_in_host.py: Look for more spaces when looking for vlan actions

### DIFF
--- a/recipes/ovs_offload/03-vlan_in_host.py
+++ b/recipes/ovs_offload/03-vlan_in_host.py
@@ -47,13 +47,13 @@ ping_mod6 = ctl.get_module("Icmp6Ping",
 
 
 def verify_tc_rules(proto):
-    m = tl.find_tc_rule(h1, 'tap', g1_mac, h2_mac, proto, 'vlan push')
+    m = tl.find_tc_rule(h1, 'tap', g1_mac, h2_mac, proto, 'vlan\s+push')
     if m:
         tl.custom(h1, "TC rule %s vlan push" % proto)
     else:
         tl.custom(h1, "TC rule %s vlan push" % proto, 'ERROR: cannot find tc rule')
 
-    m = tl.find_tc_rule(h1, 'nic', h2_mac, g1_mac, proto, 'vlan pop')
+    m = tl.find_tc_rule(h1, 'nic', h2_mac, g1_mac, proto, 'vlan\s+pop')
     if m:
         tl.custom(h1, "TC rule %s vlan pop" % proto)
     else:


### PR DESCRIPTION
This is due to supporting Ubuntu where tc rules actions has more
than one space in it.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>