### PR TITLE
Updated r-vrt-24-120 and r-vrt-24-180 pool cfg files

### DIFF
--- a/load-r-vrt-24-120.sh
+++ b/load-r-vrt-24-120.sh
@@ -1,28 +1,57 @@
-#!/bin/sh
+#!/bin/bash
 
-CX4=eth4
-CX4_2=eth5
+CX4=ens2f0
+CX4_2=ens2f1
 
-CX5=eth4
-CX5_2=eth5
+CX5=ens1f0
+CX5_2=ens1f1
 
 if [ "$1" == "cx5" ]; then
     nic=$CX5
     nic2=$CX5_2
+    vms=`seq 121 122`
 else
     nic=$CX4
     nic2=$CX4_2
+    vms=`seq 5 6`
 fi
 
 vfs=2
-vms="gen-h-vrt-018-005 gen-h-vrt-018-006"
+hv=`hostname -s`
 
 ##############################################################################
 
-function set_modes() {
-    local pci=$(basename `readlink /sys/class/net/$nic/device`)
-    devlink dev eswitch set pci/$pci inline-mode transport
-#    devlink dev eswitch set pci/$pci encap yes
+if [ -e /sys/kernel/debug/mlx5/$pci/compat ]; then
+    echo "devlink compat debugfs"
+    devlink_compat=1
+    restart_openibd=1
+    __devlink_compat_dir="/sys/kernel/debug/mlx5/$pci/compat"
+elif [ -e /sys/class/net/$nic/compat/devlink ]; then
+    echo "devlink compat sysfs"
+    devlink_compat=1
+    restart_openibd=1
+    __devlink_compat_dir="/sys/class/net/$nic/compat/devlink"
+fi
+
+function set_mode() {
+    local pci=$(basename `readlink /sys/class/net/$1/device`)
+
+    if [ "$devlink_compat" = 1 ]; then
+        echo $2 > $__devlink_compat_dir/mode
+    else
+        devlink dev eswitch set pci/$pci mode $2
+	echo devlink dev eswitch set pci/$pci mode $2
+    fi
+}
+
+function set_eswitch_inline_mode() {
+    local pci=$(basename `readlink /sys/class/net/$1/device`)
+
+    if [ "$devlink_compat" = 1 ]; then
+        echo $2 > $__devlink_compat_dir/inline
+    else
+        devlink dev eswitch set pci/$pci inline-mode $2
+    fi
 }
 
 function reset_tc_nic() {
@@ -37,7 +66,9 @@ function reset_tc_nic() {
     tc qdisc add dev $nic1 ingress
 
     # activate hw offload
-    ethtool -K $nic1 hw-tc-offload on
+    if [ "$devlink_compat" != 1 ]; then
+        ethtool -K $nic1 hw-tc-offload on
+    fi
 }
 
 function reset_tc() {
@@ -55,7 +86,7 @@ function stop_sriov() {
 
     for n in $nic $nic2 ; do
         sriov=/sys/class/net/$n/device/sriov_numvfs
-        /labhome/roid/scripts/ovs/devlink-mode.sh $n legacy
+        set_mode $n legacy
         if [ -e $sriov ]; then
             echo 0 > $sriov
         fi
@@ -80,13 +111,13 @@ function stop_vms() {
 
 function start_vms() {
     echo "Start vms"
-    for i in $vms; do virsh -q start $i-SLES-15 ; done
+    for i in $vms; do virsh -q start ${hv}-${i}-RH-7.2 ; done
 }
 
 function wait_vms() {
     echo "Wait vms"
     for i in $vms; do
-        wait_vm $i
+        wait_vm ${hv}-${i}
         break; # waiting for the first one
     done
 }
@@ -96,7 +127,7 @@ function wait_vm() {
 
     for i in 1 2 3 4; do
         ping -q -w 1 -c 1 $vm && break
-        sleep 10
+        sleep 15
     done
 
     sleep 10 ; # wait little more for lnst to be up
@@ -119,6 +150,13 @@ function clean() {
     reset_ovs
     reset_tc
     stop_sriov
+
+    for i in `ip l show type vxlan`; do
+        ip l del dev $i
+    done
+    for i in `ip l show type dummy`; do
+        ip l del dev $i
+    done
 }
 
 function warn_extra() {
@@ -133,6 +171,13 @@ function reload_modules() {
     echo "Reload modules"
     set -e
     local modules="mlx5_ib mlx5_core devlink cls_flower"
+
+    if [ -e /etc/init.d/openibd ]; then
+        service openibd force-restart
+        set +e
+        return
+    fi
+
     for m in $modules ; do
         warn_extra $m
     done
@@ -176,14 +221,15 @@ reset_tc
 
 echo "Change mode to switchdev"
 unbind
-/labhome/roid/scripts/ovs/devlink-mode.sh $nic switchdev
+set_mode $nic switchdev
+set_eswitch_inline_mode $nic transport
 if [ "$NICS" == "2" ]; then
-    /labhome/roid/scripts/ovs/devlink-mode.sh $nic2 switchdev
+    set_mode $nic2 switchdev
+    set_eswitch_inline_mode $nic2 transport
 fi
 sleep 2
 nic_up
 reset_tc
-set_modes
 
 if [ "$WITH_VMS" == "1" ]; then
     start_vms

--- a/r-vrt-24-120/r-vrt-24-120.xml
+++ b/r-vrt-24-120/r-vrt-24-120.xml
@@ -1,24 +1,24 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.17.1" />
+        <param name="hostname" value="10.213.24.120" />
         <param name="ovs_support" value="true" />
         <param name="machine_type" value="baremetal" />
         <param name="order" value="1" />
     </params>
     <interfaces>
-        <eth id="p1p1" label="uplink">
+        <eth id="ens1f0" label="uplink">
             <params>
-		    <param name="hwaddr" value="50:6b:4b:08:86:16" />
+		    <param name="hwaddr" value="50:6b:4b:0d:11:46" />
             </params>
         </eth>
-        <eth id="rep_p1p1_0" label="net-vm1">
+        <eth id="ens1f0_0" label="net-vm1">
             <params>
-                <param name="hwaddr" value="ce:3c:54:ee:b9:22" />
+                <param name="hwaddr" value="42:2b:57:ad:1d:39" />
             </params>
         </eth>
-        <eth id="rep_p1p1_1" label="net-vm2">
+        <eth id="ens1f0_1" label="net-vm2">
             <params>
-                <param name="hwaddr" value="be:ec:f3:c5:fe:ee" />
+                <param name="hwaddr" value="5e:a9:f0:e8:45:66" />
             </params>
         </eth>
     </interfaces>

--- a/r-vrt-24-120/r-vrt-24-180.xml
+++ b/r-vrt-24-120/r-vrt-24-180.xml
@@ -1,13 +1,13 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.18.1" />
+        <param name="hostname" value="10.213.24.180" />
         <param name="ovs_support" value="true" />
         <param name="machine_type" value="baremetal" />
     </params>
     <interfaces>
-        <eth id="eth4" label="uplink">
+        <eth id="eth2" label="uplink">
             <params>
-		    <param name="hwaddr" value="50:6b:4b:08:85:9e" />
+		    <param name="hwaddr" value="24:8a:07:ad:0b:e8" />
             </params>
         </eth>
     </interfaces>

--- a/r-vrt-24-120/update-r-vrt-24-120.py
+++ b/r-vrt-24-120/update-r-vrt-24-120.py
@@ -8,8 +8,8 @@ import re
 import xml.etree.ElementTree as ET
 
 
-host = 'gen-h-vrt-018'
-xml = 'gen-h-vrt-018/gen-h-vrt-018.xml'
+host = 'r-vrt-24-120'
+xml = 'r-vrt-24-120/r-vrt-24-120.xml'
 
 
 AF_LINK = 17

--- a/r-vrt-24-120/vm120-005.xml
+++ b/r-vrt-24-120/vm120-005.xml
@@ -1,12 +1,12 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.17.6"/>
+        <param name="hostname" value="10.213.24.121"/>
         <param name="machine_type" value="guest"/>
     </params>
     <interfaces>
-        <eth id="ens6" label="net-vm2">
+        <eth id="ens6" label="net-vm1">
             <params>
-                <param name="hwaddr" value="e4:11:22:86:16:51"/>
+                <param name="hwaddr" value="e4:11:22:11:46:50"/>
             </params>
         </eth>
     </interfaces>

--- a/r-vrt-24-120/vm120-006.xml
+++ b/r-vrt-24-120/vm120-006.xml
@@ -1,12 +1,12 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.17.5"/>
+        <param name="hostname" value="10.213.24.122"/>
         <param name="machine_type" value="guest"/>
     </params>
     <interfaces>
-        <eth id="ens6" label="net-vm1">
+        <eth id="ens6" label="net-vm2">
             <params>
-                <param name="hwaddr" value="e4:11:22:86:16:50"/>
+                <param name="hwaddr" value="e4:11:22:11:46:51"/>
             </params>
         </eth>
     </interfaces>

--- a/r-vrt-24-180/r-vrt-24-120.xml
+++ b/r-vrt-24-180/r-vrt-24-120.xml
@@ -1,13 +1,13 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.17.1" />
+        <param name="hostname" value="10.213.24.120" />
         <param name="ovs_support" value="true" />
         <param name="machine_type" value="baremetal" />
     </params>
     <interfaces>
-        <eth id="eth4" label="uplink">
+        <eth id="ens1f0" label="uplink">
             <params>
-		    <param name="hwaddr" value="50:6b:4b:08:86:16" />
+		    <param name="hwaddr" value="50:6b:4b:0d:11:46" />
             </params>
         </eth>
     </interfaces>

--- a/r-vrt-24-180/r-vrt-24-180.xml
+++ b/r-vrt-24-180/r-vrt-24-180.xml
@@ -1,22 +1,22 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.18.1" />
+        <param name="hostname" value="10.213.24.180" />
         <param name="ovs_support" value="true" />
         <param name="machine_type" value="baremetal" />
         <param name="order" value="1" />
     </params>
     <interfaces>
-        <eth id="eth4" label="uplink">
+        <eth id="eth2" label="uplink">
             <params>
-		    <param name="hwaddr" value="50:6b:4b:08:85:9e" />
+		    <param name="hwaddr" value="24:8a:07:ad:0b:e8" />
             </params>
         </eth>
-        <eth id="eth4_0" label="net-vm1">
+        <eth id="eth2_0" label="net-vm1">
             <params>
                 <param name="hwaddr" value="66:9f:69:7c:cc:aa" />
             </params>
         </eth>
-        <eth id="eth4_1" label="net-vm2">
+        <eth id="eth2_1" label="net-vm2">
             <params>
                 <param name="hwaddr" value="2a:4a:34:ca:e4:38" />
             </params>

--- a/r-vrt-24-180/update-r-vrt-24-180.py
+++ b/r-vrt-24-180/update-r-vrt-24-180.py
@@ -8,8 +8,8 @@ import re
 import xml.etree.ElementTree as ET
 
 
-host = 'gen-h-vrt-017'
-xml = 'gen-h-vrt-017/gen-h-vrt-017.xml'
+host = 'r-vrt-24-180'
+xml = 'r-vrt-24-180/r-vrt-24-180.xml'
 
 
 AF_LINK = 17

--- a/r-vrt-24-180/vm180-005.xml
+++ b/r-vrt-24-180/vm180-005.xml
@@ -1,6 +1,6 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.18.5"/>
+        <param name="hostname" value="10.213.24.181"/>
         <param name="machine_type" value="guest"/>
     </params>
     <interfaces>

--- a/r-vrt-24-180/vm180-006.xml
+++ b/r-vrt-24-180/vm180-006.xml
@@ -1,6 +1,6 @@
 <slavemachine>
     <params>
-        <param name="hostname" value="10.196.18.6"/>
+        <param name="hostname" value="10.213.24.182"/>
         <param name="machine_type" value="guest"/>
     </params>
     <interfaces>


### PR DESCRIPTION
This is due to change using servers gen-vrt-017/018 to
servers r-vrt-24-120/180 for RHEL 7.5 and SLES 15.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>