### PR TITLE
load-reg019-060.sh: Disable devlink reload

### DIFF
--- a/load-reg019-060.sh
+++ b/load-reg019-060.sh
@@ -132,7 +132,8 @@ function warn_extra() {
 function reload_modules() {
     echo "Reload modules"
     set -e
-    local modules="mlx5_ib mlx5_core devlink cls_flower"
+    local modules="mlx5_ib mlx5_core cls_flower"
+    
     for m in $modules ; do
         warn_extra $m
     done


### PR DESCRIPTION
This is due to the upstream kernel consider it as a builtin module.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>