### PR TITLE
1_virt_ovs_vxlan.py: Switch searching for vxlan devices

### DIFF
--- a/recipes/ovs_offload/1_virt_ovs_vxlan.py
+++ b/recipes/ovs_offload/1_virt_ovs_vxlan.py
@@ -64,10 +64,10 @@ def get_vxlan_dev(host):
     cmd = host.run("ls /sys/class/net")
     out = cmd.out().strip().split()
 
-    if vxlan_dev in out:
-        return vxlan_dev
-    elif vxlan_dummy in out:
+    if vxlan_dummy in out:
         return vxlan_dummy
+    elif vxlan_dev in out:
+        return vxlan_dev
     else:
         raise RuntimeError("Cannot find vxlan device")
 


### PR DESCRIPTION
This due to on CentOS 7.2 with Kernel 4.9, the ingress rules
is in dummy_<port>.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>