### PR TITLE
Add one more loop to check if vms are up and unify sleep time to 15

### DIFF
--- a/load-dev002.sh
+++ b/load-dev002.sh
@@ -125,7 +125,7 @@ function wait_vms() {
 function wait_vm() {
     local vm=$1
 
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         ping -q -w 1 -c 1 $vm && break
         sleep 15
     done

--- a/load-dev229.sh
+++ b/load-dev229.sh
@@ -125,9 +125,9 @@ function wait_vms() {
 function wait_vm() {
     local vm=$1
 
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         ping -q -w 1 -c 1 $vm && break
-        sleep 12
+        sleep 15
     done
 
     sleep 15 ; # wait little more for lnst to be up

--- a/load-r-vrt-24-120.sh
+++ b/load-r-vrt-24-120.sh
@@ -125,7 +125,7 @@ function wait_vms() {
 function wait_vm() {
     local vm=$1
 
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         ping -q -w 1 -c 1 $vm && break
         sleep 15
     done

--- a/load-r-vrt-24-180.sh
+++ b/load-r-vrt-24-180.sh
@@ -125,7 +125,7 @@ function wait_vms() {
 function wait_vm() {
     local vm=$1
 
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         ping -q -w 1 -c 1 $vm && break
         sleep 15
     done

--- a/load-reg019-001.sh
+++ b/load-reg019-001.sh
@@ -125,7 +125,7 @@ function wait_vms() {
 function wait_vm() {
     local vm=$1
 
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         ping -q -w 1 -c 1 $vm && break
         sleep 15
     done

--- a/load-reg019-060.sh
+++ b/load-reg019-060.sh
@@ -94,12 +94,12 @@ function wait_vms() {
 function wait_vm() {
     local vm=$1
 
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         ping -q -w 1 -c 1 $vm && break
-        sleep 10
+        sleep 15
     done
 
-    sleep 10 ; # wait little more for lnst to be up
+    sleep 15 ; # wait little more for lnst to be up
 }
 
 function del_ovs_bridges() {


### PR DESCRIPTION
This is due to installing dbg kernel that takes more time to get it up.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>